### PR TITLE
CMakeLists.txt: fix some library searching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ if(NOT BUILD_ONLY_CEF)
   endif()
   find_package(BZip2 ${REQUIRED_IF_OPTION})
   find_package(Sqlite ${REQUIRED_IF_OPTION})
+  find_package(v8 ${REQUIRED_IF_OPTION})
 
   if(NOT FORCE_BUNDLED_WXGTK)
     find_package(wxWidgets 2.9.5 COMPONENTS richtext ${REQUIRED_IF_OPTION})


### PR DESCRIPTION
Boost thread is no longer needed.

On Linux we need to search for tinyxml package instead of tinyxml2.
