### PR TITLE
travis: multiple fixes including update to gcc4.8 and clang3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,12 @@ language: cpp
 compiler:
   - gcc
   - clang
-env:
-  - CFLAGS=--coverage CXXFLAGS=--coverage
 before_install:
   - sudo add-apt-repository --yes ppa:makson96/desurium-travis
   - sudo apt-get update
   - sudo apt-get install -qq libnotify-dev libboost1.48-dev libboost-filesystem1.48-dev libboost-system1.48-dev libgtest-dev libwxgtk3.0-dev wx-common clang-3.4 cmake gcc-4.8 g++-4.8 gcc-4.8-multilib
   - if [ $CC == "clang" ]; then export CC=clang-3.4 && export CXX=clang++-3.4; fi
   - if [ $CC == "gcc" ]; then export CC=gcc-4.8 && export CXX=g++-4.8; fi
-  - sudo pip install cpp-coveralls --use-mirrors
 script:
   - cmake . -DBUILD_CEF=off -DDEBUG=on -DWITH_GTEST=ON -DBUILD_TESTS=ON
   - make -j4


### PR DESCRIPTION
This pull request is binding travis to our repo, which results in:
cmake  2.8.12.1
gcc 4.8.1
clang/llvm 3.4
We are now also using wx 3.0 from this repo.

Please close: #743
