### PR TITLE
Update Package.cmake to make valid debian package

### DIFF
--- a/cmake/modules/Package.cmake
+++ b/cmake/modules/Package.cmake
@@ -42,7 +42,7 @@ else(64BIT)
 endif(64BIT)
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Tomasz Makarewicz <makson96@gmail.com>")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcurl3 libevent-dev libjpeg8 libtinyxml-dev libboost-filesystem-dev libnss3 libnotify4 libxt6 libwxgtk3.0-0")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcurl3, libevent-dev, libjpeg8, libtinyxml-dev, libboost-filesystem-dev, libnss3, libnotify4, libxt6, libwxgtk3.0-0")
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
 


### PR DESCRIPTION
Debian package depends need commas between packages. This makes an invalid package otherwise.
